### PR TITLE
feat: shadow toc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ goread
 bin/
 toc.ncx
 release
+content.opf


### PR DESCRIPTION
Sometimes some small chapters are not saved in toc.ncx, but are recorded in the spine element. 
Therefore, when the number of toc elements is less than the number of spine elements, supplement the navigation nodes from the spine, mark them as isShadow: true, and do not display them in the toc navigation (because most of them do not have titles).